### PR TITLE
Resolve bug due to improper inheritance order of Mixin

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -4,4 +4,4 @@ pandas==0.24.2
 opencv-python==4.2.0.32
 pillow==9.0.0
 matplotlib==3.1.1
-jupyter_innotater==0.3.0
+jupyter_innotater==0.3.1

--- a/jupyter-innotater/jupyter_innotater/combine.py
+++ b/jupyter-innotater/jupyter_innotater/combine.py
@@ -55,7 +55,7 @@ class GroupedInnotation(Innotation):
         return 0
 
 
-class RepeatInnotation(Innotation, ChildrenChangeNotifierMixin):
+class RepeatInnotation(ChildrenChangeNotifierMixin, Innotation):
 
     def __init__(self, *args, **kwargs):
 

--- a/jupyter-innotater/jupyter_innotater/data.py
+++ b/jupyter-innotater/jupyter_innotater/data.py
@@ -23,7 +23,6 @@ class Innotation:
     anonindex = 1
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
         if 'name' in kwargs:
             self.name = kwargs['name']
@@ -68,7 +67,7 @@ class Innotation:
         return [self]
 
 
-class ImageInnotation(Innotation, DataMixin):
+class ImageInnotation(DataMixin, Innotation):
 
     def __init__(self, *args, **kwargs):
 
@@ -163,7 +162,7 @@ class ImageInnotation(Innotation, DataMixin):
         return self.get_widget().rects[watcher_index*4:(watcher_index+1)*4]
 
 
-class BoundingBoxInnotation(Innotation, DataMixin):
+class BoundingBoxInnotation(DataMixin, Innotation):
 
     def __init__(self, *args, **kwargs):
 
@@ -252,7 +251,7 @@ class BoundingBoxInnotation(Innotation, DataMixin):
             self.sourcedw.set_current_watcher(self.name, self.repeat_index)
 
 
-class MultiClassInnotation(Innotation, DataMixin):
+class MultiClassInnotation(DataMixin, Innotation):
 
     def __init__(self, *args, **kwargs):
 
@@ -341,7 +340,7 @@ class BinaryClassInnotation(MultiClassInnotation):
         return self.classes[self.get_widget().value and 1 or 0]
 
 
-class TextInnotation(Innotation, DataMixin):
+class TextInnotation(DataMixin, Innotation):
 
     def __init__(self, *args, **kwargs):
 

--- a/jupyter-innotater/jupyter_innotater/mixins.py
+++ b/jupyter-innotater/jupyter_innotater/mixins.py
@@ -3,6 +3,7 @@ from ipywidgets.widgets import CallbackDispatcher
 
 class DataMixin:
   def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
     self.repeat_index = kwargs.get('repeat_index', -1)
 
     if len(args) > 0:
@@ -41,6 +42,7 @@ class DataMixin:
 class DataChangeNotifierMixin:
 
   def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
     self.repeat_index = kwargs.get('repeat_index', -1)
     self._data_changed_handlers = CallbackDispatcher()
 
@@ -71,6 +73,7 @@ class DataChangeNotifierMixin:
 class ChildrenChangeNotifierMixin:
 
   def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
     self._children_changed_handlers = CallbackDispatcher()
 
   def on_children_changed(self, callback, remove=False):

--- a/jupyter-innotater/jupyter_innotater/uiinnotations.py
+++ b/jupyter-innotater/jupyter_innotater/uiinnotations.py
@@ -6,7 +6,7 @@ from .data import Innotation
 from .mixins import DataChangeNotifierMixin
 
 
-class ButtonInnotation(Innotation, DataChangeNotifierMixin):
+class ButtonInnotation(DataChangeNotifierMixin, Innotation):
     """
     Allow embedding of an arbitrary widget object, e.g. for text display
     Must still have a data attribute of correct len, even if dummy values

--- a/jupyter-innotater/package.json
+++ b/jupyter-innotater/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-innotater",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "An Inline Data Annotator for Jupyter",
   "keywords": [
     "jupyter",

--- a/tests/test_repeat_innotation.py
+++ b/tests/test_repeat_innotation.py
@@ -1,0 +1,29 @@
+from jupyter_innotater import RepeatInnotation
+from jupyter_innotater.data import BoundingBoxInnotation, MultiClassInnotation, TextInnotation
+import ipywidgets
+import numpy as np 
+
+
+class TestRepeatInnotation:
+    def test_constructor(self):
+        classes = ['a', 'b']
+        num_repeats = 4
+        num_samples = 10
+        RepeatInnotation(
+            (
+                MultiClassInnotation, 
+                np.zeros((num_samples, num_repeats, len(classes)), dtype='int'), 
+                dict(name='Type', classes=classes, dropdown=True, layout=ipywidgets.Layout(width='150px'))
+            ),(
+                BoundingBoxInnotation, 
+                np.zeros((num_samples, num_repeats, 4), dtype='int'),
+                {'layout': ipywidgets.Layout(width='175px')}
+            ),(
+                TextInnotation, 
+                np.zeros((num_samples, num_repeats, len(classes)), dtype=str), 
+                {'layout': ipywidgets.Layout(width='40px'), 'multiline': False}
+            ),
+            max_repeats=num_repeats,
+            min_repeats=num_repeats,
+            layout='50%'
+        )


### PR DESCRIPTION
Mixins should be imported first and should propagate the init arguments to the following class in the inheritence tree.
Added a test to show the improvement.