### PR TITLE
adding requirements.txt

### DIFF
--- a/jupyter-innotater/MANIFEST.in
+++ b/jupyter-innotater/MANIFEST.in
@@ -2,6 +2,7 @@ include LICENSE
 include README.md
 include pyproject.toml
 include jupyter-config/jupyter_innotater.json
+include requirements.txt
 
 include package.json
 include install.json


### PR DESCRIPTION
Hello! I'm a conda-forge recipe contributor and just wanted to add this to make sure that 0.3.1 is available in conda-forge. Thanks! 

Here's the [jupyter_innotater-feedstock `FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'`](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=468516&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d&l=642) I'm running into. 